### PR TITLE
Zephyr integration

### DIFF
--- a/sample-implementations/GPIO_bit_banging/sensirion_i2c_hal.c
+++ b/sample-implementations/GPIO_bit_banging/sensirion_i2c_hal.c
@@ -70,6 +70,12 @@ void sensirion_i2c_hal_init(void) {
 }
 
 /**
+ * Initialize driver by setting device initialized in 3rd party
+ */
+void sensirion_i2c_hal_set_dev(void *dev) {
+}
+
+/**
  * Release all resources initialized by sensirion_i2c_hal_init().
  */
 void sensirion_i2c_hal_free(void) {

--- a/sample-implementations/Nordic_nRF5_series/sensirion_i2c_hal.c
+++ b/sample-implementations/Nordic_nRF5_series/sensirion_i2c_hal.c
@@ -74,6 +74,12 @@ void sensirion_i2c_hal_init(void) {
 }
 
 /**
+ * Initialize driver by setting device initialized in 3rd party
+ */
+void sensirion_i2c_hal_set_dev(void *dev) {
+}
+
+/**
  * Release all resources initialized by sensirion_i2c_hal_init().
  */
 void sensirion_i2c_hal_free(void) {

--- a/sample-implementations/STM32F1_series/sensirion_i2c_hal.c
+++ b/sample-implementations/STM32F1_series/sensirion_i2c_hal.c
@@ -64,6 +64,12 @@ void sensirion_i2c_hal_init(void) {
 }
 
 /**
+ * Initialize driver by setting device initialized in 3rd party
+ */
+void sensirion_i2c_hal_set_dev(void *dev) {
+}
+
+/**
  * Release all resources initialized by sensirion_i2c_hal_init().
  */
 void sensirion_i2c_hal_free(void) {

--- a/sample-implementations/linux_user_space/sensirion_i2c_hal.c
+++ b/sample-implementations/linux_user_space/sensirion_i2c_hal.c
@@ -72,6 +72,12 @@ void sensirion_i2c_hal_init(void) {
 }
 
 /**
+ * Initialize driver by setting device initialized in 3rd party
+ */
+void sensirion_i2c_hal_set_dev(void *dev) {
+}
+
+/**
  * Release all resources initialized by sensirion_i2c_hal_init().
  */
 void sensirion_i2c_hal_free(void) {

--- a/sample-implementations/mbed/sensirion_i2c_hal.cpp
+++ b/sample-implementations/mbed/sensirion_i2c_hal.cpp
@@ -48,6 +48,12 @@ void sensirion_i2c_hal_init(void) {
 }
 
 /**
+ * Initialize driver by setting device initialized in 3rd party
+ */
+void sensirion_i2c_hal_set_dev(void *dev) {
+}
+
+/**
  * Release all resources initialized by sensirion_i2c_hal_init().
  */
 void sensirion_i2c_hal_free(void) {

--- a/sample-implementations/zephyr_user_space/sensirion_i2c_hal.c
+++ b/sample-implementations/zephyr_user_space/sensirion_i2c_hal.c
@@ -37,6 +37,11 @@
 #include "sensirion_config.h"
 #include "sensirion_i2c_hal.h"
 
+typedef enum {
+    STATUS_FAIL = -EIO,
+    STATUS_OK   = 0,
+} status_t;
+
 /* I2C device. */
 static struct device* i2c_dev;
 
@@ -72,6 +77,13 @@ int16_t sensirion_i2c_hal_select_bus(uint8_t bus_idx) {
 void sensirion_i2c_hal_init(void) {
     /* Device (specified by sps30_i2c_dev) is already initialized by the Zephyr
      * boot-up process. Nothing to be done here. */
+}
+
+/**
+ * Initialize driver by setting device initialized in 3rd party
+ */
+void sensirion_i2c_hal_set_dev(void *dev) {
+    i2c_dev = dev;
 }
 
 /**

--- a/sensirion_i2c_hal.c
+++ b/sensirion_i2c_hal.c
@@ -67,6 +67,13 @@ void sensirion_i2c_hal_init(void) {
 }
 
 /**
+ * Initialize driver by setting device initialized in 3rd party
+ */
+void sensirion_i2c_hal_set_dev(void *dev) {
+    /* TODO:IMPLEMENT */
+}
+
+/**
  * Release all resources initialized by sensirion_i2c_hal_init().
  */
 void sensirion_i2c_hal_free(void) {

--- a/sensirion_i2c_hal.h
+++ b/sensirion_i2c_hal.h
@@ -57,6 +57,11 @@ int16_t sensirion_i2c_hal_select_bus(uint8_t bus_idx);
 void sensirion_i2c_hal_init(void);
 
 /**
+ * Initialize driver by setting device initialized in 3rd party
+ */
+void sensirion_i2c_hal_set_dev(void *dev);
+
+/**
  * Release all resources initialized by sensirion_i2c_hal_init().
  */
 void sensirion_i2c_hal_free(void);

--- a/zephyr/CMakeLists.txt
+++ b/zephyr/CMakeLists.txt
@@ -1,0 +1,8 @@
+zephyr_sources(
+    ../scd4x_i2c.c
+    ../sensirion_common.c
+    ../sample-implementations/zephyr_user_space/sensirion_i2c_hal.c
+    ../sensirion_i2c.c
+)
+
+zephyr_include_directories(..)

--- a/zephyr/module.yml
+++ b/zephyr/module.yml
@@ -1,0 +1,2 @@
+build:
+  cmake: ./zephyr/


### PR DESCRIPTION
## zephyr directory

Added a zephyr directory in order it can be used as a zephyr 3rd party, by west.yml

## Hal:  Add  Set device function

A new function was added in order to let the initialization process to be outsourced. This would be a good idea in order to automate the initialization process, by changing only the dts. In any other case, changes should happen in the callee of the init (etc zephyr driver) which is not the best solution. For example, you can see how I implemented the init function in our zephyr driver.

```
static int sensirion_scd4x_init(struct device *dev)
{
    struct scd4x_data *drv_data;

    drv_data = dev->driver_data;

    drv_data->i2c_dev = device_get_binding(DT_INST_BUS_LABEL(0));
    if (drv_data->i2c_dev == NULL) {
        LOG_DBG("Failed to initialize %s device!", DT_INST_BUS_LABEL(0));
        return -EINVAL;
    }
    sensirion_i2c_hal_set_dev(drv_data->i2c_dev);

    return 0;
}
```
